### PR TITLE
#3 Added a simple branding icon 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Equella integration Web Components for the uPortal ecosystem.
 
+You will need Node 8.x.
+
 ## Initial Setup
 
 ```console

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Equella integration Web Components for the uPortal ecosystem.
 
-You will need Node 8.x.
+You will need Node 8+ and Git 1+ to use this project.
 
 ## Initial Setup
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="search-results">
+  <div class="container search-results">
+    <img src="https://equella.unicon.net/demo-oa18-up-eq-integ/s/ewc-logo" class="img-rounded pull-right" alt="EQUELLA Logo" height="80">
     <h1>{{ msg }}</h1>
     <p>
       Found the following items in Equella.

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container search-results">
+  <div class="search-results">
     <img src="https://equella.unicon.net/demo-oa18-up-eq-integ/s/ewc-logo" class="img-rounded pull-right" alt="EQUELLA Logo" height="80">
     <h1>{{ msg }}</h1>
     <p>


### PR DESCRIPTION
The branding icon lives in Equella, accessed via an Equella 'shortcut URL' so the image can change without rebuilding the web component.

Also updated the readme with a note to use Node 8.